### PR TITLE
fix: drop sharp tsconfig path mapping that broke sharp at runtime

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,6 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ],
-      "sharp": [
-        "./node_modules/sharp/lib/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
## The failure

Every screenshot request in production was failing with:

```
Error accessing page: TypeError: (void 0) is not a function
    at u (.next/server/chunks/[root-of-the-server]__0i10l2f._.js:1:33298)
    at o (.next/server/chunks/[root-of-the-server]__0i10l2f._.js:1:33033)
```

The route caught it and returned `500 {"error":"Failed to generate screenshot"}`.

## Root cause

`tsconfig.json` carried this workaround:

```json
"sharp": ["./node_modules/sharp/lib/index.d.ts"]
```

It was added when sharp 0.35.0 shipped an `exports` map with no `types` condition, which broke type resolution under `moduleResolution: "bundler"`.

The problem is that `paths` is not a tsc-only setting — Turbopack honors it for real module resolution. So `import sharp from "sharp"` resolved to a **declaration file**, which compiles to an empty module. Both call sites minified to `(void 0)(...)`:

```js
async function u(e,t,r){let n=(void 0)(e);   // convertImageFormat
async function s(e,t,r,n){let a=(void 0)(e); // resizeImage
```

Since `DEFAULT_TYPE` is `webp` and `DEFAULT_SCALE` is `0.25`, a request with no `type`/`scale` params hits both functions — so the endpoint was broken for essentially all traffic. The build stayed green the whole time because the types resolved fine; only the runtime value was missing.

## The fix

Remove the mapping. sharp 0.35.3 declares `types` under both the `import` and `require` conditions, so the original workaround is obsolete:

```json
".": {
  "import":  { "types": "./dist/index.d.mts", "default": "./dist/index.mjs" },
  "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
}
```

## Verification

- `npx tsc --noEmit` — clean, so the mapping is genuinely no longer needed.
- Rebuilt: the call sites now emit `(0, i.default)(e)` instead of `(void 0)(e)`, and no `(void 0)(` calls remain in any server chunk.
- Ran `next start` with `NODE_ENV=production` against the new build and requested every format:

| request | result |
|---|---|
| `type=png` | 200, `PNG image data, 200 x 150` |
| `type=jpeg` | 200, `JPEG image data, 200x150` |
| `type=webp` | 200, `Web/P image, 200x150` |
| `type=avif` | 200, `ISO Media, AVIF Image` |
| `scale=0.5` (resize path) | 200, `Web/P image, 400x300` |

No errors in the server log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an obsolete internal path alias from the project configuration.
  * Existing source path resolution remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->