### PR TITLE
Speed up Build & Deploy container caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,8 +85,14 @@ jobs:
           tags: |
             ${{ steps.meta.outputs.image }}:latest
             ${{ steps.meta.outputs.image }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # GHCR keeps the cache across quiet periods. The Actions cache used
+          # here previously expires after inactivity and made the next deploy
+          # re-upload the large Chromium layers. Keep it as a migration source
+          # until the registry cache has been populated by the first run.
+          cache-from: |
+            type=registry,ref=${{ steps.meta.outputs.image }}:buildcache
+            type=gha
+          cache-to: type=registry,ref=${{ steps.meta.outputs.image }}:buildcache,mode=max
 
       # The non-empty check above cannot tell whether the token still WORKS. An
       # expired or revoked one would sail past it, and then saveDockerProvider

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ COPY . .
 RUN npm run build
 
 # =====================================================================
-# Runtime
+# Browser runtime base
 # =====================================================================
-FROM ${NODE_IMAGE} AS runtime
+FROM ${NODE_IMAGE} AS browser
 WORKDIR /app
 
 ENV NODE_ENV=production \
@@ -54,19 +54,26 @@ ENV NODE_ENV=production \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY --from=dependencies /app/node_modules ./node_modules
+
+# Install the Chromium build that matches the Playwright version resolved in
+# bun.lock, rather than pinning a browser image tag that would silently drift
+# out of sync the next time playwright is bumped. --with-deps pulls the shared
+# libraries headless Chromium needs on a slim base. This stage deliberately has
+# no build output: application-only changes can reuse the large browser layer.
+RUN npx --yes playwright install --with-deps chromium \
+    && rm -rf /var/lib/apt/lists/* \
+    && chown -R node:node /app /ms-playwright
+
+# =====================================================================
+# Runtime
+# =====================================================================
+FROM browser AS runtime
+
 COPY --from=build /app/.next ./.next
 # No `public/` here: the directory exists locally but is untracked, so it does
 # not exist in a clean checkout and a COPY of it fails the build in CI.
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/next.config.ts ./next.config.ts
-
-# Install the Chromium build that matches the Playwright version resolved in
-# bun.lock, rather than pinning a browser image tag that would silently drift
-# out of sync the next time playwright is bumped. --with-deps pulls the shared
-# libraries headless Chromium needs on a slim base.
-RUN npx --yes playwright install --with-deps chromium \
-    && rm -rf /var/lib/apt/lists/* \
-    && chown -R node:node /app /ms-playwright
 
 # Root was only needed for the apt install above. Chromium is launched with
 # --no-sandbox (see src/app/api/screenshot/helpers.ts), which is what lets it


### PR DESCRIPTION
## What changed

- store the production BuildKit cache in GHCR so it survives quiet periods
- retain the GitHub Actions cache as a migration source for the first registry-backed build
- move Chromium and its system dependencies into an app-independent Docker stage

## Why

The referenced deploy spent 3m50s in `Build & push image`. Its image was pushed after roughly 2m15s, but exporting the `mode=max` Actions cache added another 1m33s. The same cold-cache behavior recurred after ten days on a source-only change because the Actions cache had expired.

Keeping the cache alongside the image avoids that inactivity expiry and lets GHCR reuse image blobs instead of uploading the large Chromium layers to a second backend. Separating the browser stage also prevents ordinary source changes from invalidating the browser installation.

## Validation

- `bun run build`
- cold `linux/amd64` Docker build
- warm `linux/amd64` Docker rebuild (2.4s locally; all build steps cached)
- launched Playwright Chromium inside the built x86_64 image (`151.0.7922.34`)
- workflow YAML passes Prettier parsing/checking

`bun run lint` still hits the existing ESLint 10 / `@typescript-eslint` compatibility error on `master`; this PR does not alter JavaScript dependencies or lint configuration.
